### PR TITLE
Use relative path for configuration in DbContext factory

### DIFF
--- a/RestroLogic.Infrastructure/Persistence/AppDbContextFactory.cs
+++ b/RestroLogic.Infrastructure/Persistence/AppDbContextFactory.cs
@@ -9,10 +9,10 @@ namespace RestroLogic.Infrastructure.Persistence
     {
         public AppDbContext CreateDbContext(string[] args)
         {
-            // Busca el archivo de configuración en el proyecto WebApi
+            // Carga el archivo de configuración del proyecto WebApi mediante una ruta relativa
             IConfigurationRoot configuration = new ConfigurationBuilder()
                 .SetBasePath(Directory.GetCurrentDirectory())
-                .AddJsonFile(@"C:\Users\luis_\source\repos\RestroLogic\RestroLogic.WebApi\appsettings.json")
+                .AddJsonFile(Path.Combine(Directory.GetCurrentDirectory(), "..", "RestroLogic.WebApi", "appsettings.json"))
                 .Build();
 
             var builder = new DbContextOptionsBuilder<AppDbContext>();


### PR DESCRIPTION
## Summary
- load WebApi appsettings using relative path instead of absolute location
- clarify configuration loading comment

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed/403)*

------
https://chatgpt.com/codex/tasks/task_e_68979514bad48331944a59c387d65ec5